### PR TITLE
Clippy changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,25 +226,25 @@ mod tests {
         let gcode = move_z(1.8);
         assert_eq!("G0 Z1.8\n", gcode);
     }
-    
+
     #[test]
     fn test_relative_positioning() {
         let gcode = relative_positioning();
         assert_eq!("G91\n", gcode);
     }
-    
+
     #[test]
     fn test_absolute_positioning() {
         let gcode = absolute_positioning();
         assert_eq!("G90\n", gcode);
     }
-    
+
     #[test]
     fn test_use_inches() {
         let gcode = use_inches();
         assert_eq!("G20\n", gcode);
     }
-    
+
     #[test]
     fn test_use_millimeters() {
         let gcode = use_millimeters();
@@ -255,12 +255,12 @@ mod tests {
 
 
 /// Defines a 2 dimentional point in the XY catersian coordanant system
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::Point2d;
-/// 
+///
 /// let p1 = Point2d { x: 0.0, y: 0.0 };
 /// let p2 = Point2d { x: 10.0, y: 0.0 };
 /// let p3 = Point2d { x: 10.0, y: 10.0 };
@@ -274,12 +274,12 @@ pub struct Point2d {
 }
 
 /// Defines a 3 dimentional point in the XYZ catersian coordanant system
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::Point3d;
-/// 
+///
 /// let p1 = Point3d { x: 0.0, y: 0.0, z: 0.0 };
 /// let p2 = Point3d { x: 10.0, y: 0.0, z: 0.0 };
 /// let p3 = Point3d { x: 10.0, y: 10.0, z: 0.0 };
@@ -298,122 +298,125 @@ pub struct Point3d {
 }
 
 /// Returns a G1 or G0 command as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point2d, move_xy};
-/// 
+///
 /// let p = Point2d { x: 10.0, y: 5.0 };
 /// // move without extruding
 /// let gcode = move_xy(p, None, None);
 /// assert_eq!("G0 X10 Y5\n", gcode);
 /// ```
-/// 
+///
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point2d, move_xy};
-/// 
+///
 /// let p = Point2d { x: 10.0, y: 5.0 };
 /// // move with extrude
 /// let gcode = move_xy(p, None, Some(5.0));
 /// assert_eq!("G1 X10 Y5 E5\n", gcode);
 /// ```
-/// 
-pub fn move_xy(dest:Point2d, feed_rate: Option<u32>, flow_rate: Option<f32>) -> String {
-    let f_str: String;
-    let e_str: String;
-    if let Some(maybe_feed_rate) = feed_rate {
-        f_str = format!(" F{}", maybe_feed_rate);
-    } else {
-        f_str = format!("");
-    }
-    
-    
+///
+pub fn move_xy(dest: Point2d, feed_rate: Option<u32>, flow_rate: Option<f32>) -> String {
+    let f_str = match feed_rate {
+        Some(feed_rate) => format!(" F{}", feed_rate),
+        None => String::new(),
+    };
+
     if let Some(maybe_flow_rate) = flow_rate {
-        e_str = format!(" E{}", maybe_flow_rate);
-        return format!("G1 X{x} Y{y}{e}{f}\n", x=dest.x, y=dest.y, e=e_str, f=f_str)
-    } else {
-        return format!("G0 X{x} Y{y}{f}\n", x=dest.x, y=dest.y, f=f_str)
+        let e_str = format!(" E{}", maybe_flow_rate);
+        return format!(
+            "G1 X{x} Y{y}{e_str}{f_str}\n",
+            x = dest.x,
+            y = dest.y,
+        );
     }
 
-    
-
+    format!("G0 X{x} Y{y}{f_str}\n", x = dest.x, y = dest.y)
 }
 
 /// Takes a [Point3d] as input, returns a G1 or G0 command to move in 3 dimentionsReturns as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point3d, move_xyz};
-/// 
+///
 /// let p = Point3d { x: 10.0, y: 5.0, z: 15.0 };
 /// // move without extruding
 /// let gcode = move_xyz(p, None, None);
 /// assert_eq!("G0 X10 Y5 Z15\n", gcode);
 /// ```
-/// 
+///
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point3d, move_xyz};
-/// 
+///
 /// let p = Point3d { x: 10.0, y: 5.0, z: 0.2 };
 /// // move with extrude
 /// let gcode = move_xyz(p, None, Some(5.0));
 /// assert_eq!("G1 X10 Y5 Z0.2 E5\n", gcode);
 /// ```
-/// 
-pub fn move_xyz(dest:Point3d, feed_rate: Option<u32>, flow_rate: Option<f32>) -> String {
-    let f_str: String;
-    let e_str: String;
-    if let Some(maybe_feed_rate) = feed_rate {
-        f_str = format!(" F{}", maybe_feed_rate);
-    } else {
-        f_str = format!("");
-    }
-    
-    if let Some(maybe_flow_rate) = flow_rate {
-        e_str = format!(" E{}", maybe_flow_rate);
-        return format!("G1 X{x} Y{y} Z{z}{e}{f}\n", x=dest.x, y=dest.y, z=dest.z, e=e_str, f=f_str)
-    } else {
-        return format!("G0 X{x} Y{y} Z{z}{f}\n", x=dest.x, y=dest.y, z=dest.z, f=f_str)
+///
+pub fn move_xyz(dest: Point3d, feed_rate: Option<u32>, flow_rate: Option<f32>) -> String {
+    let f_str = match feed_rate {
+        Some(feed_rate) => format!(" F{}", feed_rate),
+        None => String::new(),
+    };
+
+    if let Some(flow_rate) = flow_rate {
+        let e_str = format!(" E{}", flow_rate);
+        return format!(
+            "G1 X{x} Y{y} Z{z}{e_str}{f_str}\n",
+            x = dest.x,
+            y = dest.y,
+            z = dest.z
+        );
     }
 
+    format!(
+        "G0 X{x} Y{y} Z{z}{f_str}\n",
+        x = dest.x,
+        y = dest.y,
+        z = dest.z
+    )
 }
 
 /// Takes an [f32] value as a location on the Z axis to move to, Returns a G0 command
 /// Useful in layerchanges and z-hops as this function does not take arguments to extrude.
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::move_z;
-/// 
+///
 /// let gcode = move_z(1.8);
 /// assert_eq!("G0 Z1.8\n", gcode);
 /// ```
 pub fn move_z(z: f32) -> String {
-    return format!("G0 Z{}\n", z)
+    format!("G0 Z{}\n", z)
 }
 
 /// Returns a G2 or G3 command as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point2d, move_xy_arc_ij};
-/// 
+///
 /// let p = Point2d { x: 125.0, y: 0.0 };
 /// // Create a Clockwise 180 degree Arc starting at 0,0 ending at 125,0 with center point 62.5,0
 /// let gcode = move_xy_arc_ij(Some(p), Some(62.5), None, None, false);
 /// assert_eq!("G2 X125 Y0 I62.5\n", gcode);
 /// ```
-/// 
+///
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point2d, move_xy, move_xy_arc_ij};
-/// 
+///
 /// let p = Point2d { x: 220.0, y: 110.0 };
 /// // Move to the point (220,110)
 /// let _ = move_xy(p, None, None);
@@ -421,187 +424,203 @@ pub fn move_z(z: f32) -> String {
 /// let gcode = move_xy_arc_ij(None, Some(110.0), Some(110.0), Some(920.0), true);
 /// assert_eq!("G3 I110 J110 E920\n", gcode);
 /// ```
-pub fn move_xy_arc_ij(dest: Option<Point2d>, x_offset: Option<f32>, y_offset: Option<f32>, flow_rate: Option<f32>, ccw: bool) -> String {
-    let x_str: String;
-    let y_str: String;
-    let i_str: String;
-    let j_str: String;
-    let e_str: String;
-    if let Some(maybe_dest) = dest {
-        x_str = format!(" X{}", maybe_dest.x);
-        y_str = format!(" Y{}", maybe_dest.y);
-    } else {
-        x_str = format!("");
-        y_str = format!("");
-    }
-    if let Some(maybe_x_offset) = x_offset {
-        i_str = format!(" I{}", maybe_x_offset);
-    } else {
-        i_str = format!("");
-    }
-    if let Some(maybe_y_offset) = y_offset {
-        j_str = format!(" J{}", maybe_y_offset);
-    } else {
-        j_str = format!("");
-    }
-    if let Some(maybe_flow_rate) = flow_rate {
-        e_str = format!(" E{}", maybe_flow_rate);
-    } else {
-        e_str = format!("");
-    }
+pub fn move_xy_arc_ij(
+    dest: Option<Point2d>,
+    x_offset: Option<f32>,
+    y_offset: Option<f32>,
+    flow_rate: Option<f32>,
+    ccw: bool,
+) -> String {
+    let (x_str, y_str) = match dest {
+        Some(dest) => (format!(" X{}", dest.x), format!(" Y{}", dest.y)),
+        None => (String::new(), String::new()),
+    };
+
+    let i_str = match x_offset {
+        Some(x_offset) => format!(" I{}", x_offset),
+        None => String::new(),
+    };
+
+    let j_str = match y_offset {
+        Some(y_offset) => format!(" J{}", y_offset),
+        None => String::new(),
+    };
+
+    let e_str = match flow_rate {
+        Some(flow_rate) => format!(" E{}", flow_rate),
+        None => String::new(),
+    };
+
     if ccw {
-        return format!("G3{x}{y}{i}{j}{e}\n", i=i_str, j=j_str, x=x_str, y=y_str, e=e_str);
-    } else {
-        return format!("G2{x}{y}{i}{j}{e}\n", i=i_str, j=j_str, x=x_str, y=y_str, e=e_str);
+        return format!(
+            "G3{x}{y}{i}{j}{e}\n",
+            i = i_str,
+            j = j_str,
+            x = x_str,
+            y = y_str,
+            e = e_str
+        );
     }
+
+    format!(
+        "G2{x}{y}{i}{j}{e}\n",
+        i = i_str,
+        j = j_str,
+        x = x_str,
+        y = y_str,
+        e = e_str
+    )
 }
 
 /// Returns a G21 command as a String
 ///
 /// Sets units to millimeters
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::use_millimeters;
-/// 
+///
 /// let gcode = use_millimeters();
 /// assert_eq!("G21\n", gcode);
 /// ```
 pub fn use_millimeters() -> String {
-    return format!("G21\n")
+    "G21\n".to_string()
 }
 
 /// Returns a G20 command as a String
-/// 
+///
 /// Sets units to inches
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::use_inches;
-/// 
+///
 /// let gcode = use_inches();
 /// assert_eq!("G20\n", gcode);
 /// ```
 pub fn use_inches() -> String {
-    return format!("G20\n")
+    "G20\n".to_string()
 }
 
 /// Returns a G90 command as a String
-/// 
+///
 /// sets all axes to absolute positioning (relative to home, ie. (0,0))
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::absolute_positioning;
-/// 
+///
 /// let gcode = absolute_positioning();
 /// assert_eq!("G90\n", gcode);
 /// ```
 pub fn absolute_positioning() -> String {
-    return format!("G90\n")
+    "G90\n".to_string()
 }
 
 /// Returns a G91 command as a String
-/// 
+///
 /// sets all axes to relative positioning (relative to nozzle/tool position)
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::relative_positioning;
-/// 
+///
 /// let gcode = relative_positioning();
 /// assert_eq!("G91\n", gcode);
 /// ```
 pub fn relative_positioning() -> String {
-    return format!("G91\n")
+    "G91\n".to_string()
 }
 
 /// Returns a G92 command to set the current nozzle/tool possition in the XY plane as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point2d, set_pos_2d};
-/// 
+///
 /// let p = Point2d { x: 125.0, y: 125.0 };
 /// let gcode = set_pos_2d(p, None);
 /// assert_eq!("G92 X125 Y125\n", gcode);
 /// ```
 pub fn set_pos_2d(pos: Point2d, extrude_pos: Option<f32>) -> String {
-    let e_str: String;
-    if let Some(maybe_extrude_pos) = extrude_pos {
-        e_str = format!(" E{}", maybe_extrude_pos);
-    } else {
-        e_str = format!("");
-    }
-    return format!("G92 X{x} Y{y}{e}\n", x=pos.x, y=pos.y, e=e_str)
+    let e_str = match extrude_pos {
+        Some(extrude_pos) => format!(" E{}", extrude_pos),
+        None => String::new(),
+    };
+
+    format!("G92 X{x} Y{y}{e_str}\n", x = pos.x, y = pos.y)
 }
 
 /// Returns a G92 command to set the current nozzle/tool possition in 3 dimentions (XYZ) as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::{Point3d, set_pos_3d};
-/// 
+///
 /// let p = Point3d { x: 125.0, y: 125.0, z: 25.0};
 /// let gcode = set_pos_3d(p, None);
 /// assert_eq!("G92 X125 Y125 Z25\n", gcode);
 /// ```
 pub fn set_pos_3d(pos: Point3d, extrude_pos: Option<f32>) -> String {
-    let e_str: String;
-    if let Some(maybe_extrude_pos) = extrude_pos {
-        e_str = format!(" E{}", maybe_extrude_pos);
-    } else {
-        e_str = format!("");
-    }
-    return format!("G92 X{x} Y{y} Z{z}{e}\n", x=pos.x, y=pos.y, z=pos.z, e=e_str)
+    let e_str = match extrude_pos {
+        Some(extrude_pos) => format!(" E{}", extrude_pos),
+        None => String::new(),
+    };
+
+    format!(
+        "G92 X{x} Y{y} Z{z}{e}\n",
+        x = pos.x,
+        y = pos.y,
+        z = pos.z,
+        e = e_str
+    )
 }
 
 /// Returns a G92 command to set the extruder possition (E axis) as a string
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::reset_extruder;
-/// 
+///
 /// let gcode = reset_extruder(0.0);
 /// assert_eq!("G92 E0\n", gcode);
 /// ```
 pub fn reset_extruder(extrude_pos: f32) -> String {
-    return format!("G92 E{}\n", extrude_pos)
+    format!("G92 E{}\n", extrude_pos)
 }
 
 /// Returns a G92.1 command to reset to machine's native possitioning offsets as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::reset_pos;
-/// 
+///
 /// let gcode = reset_pos();
 /// assert_eq!("G92.1\n", gcode);
 /// ```
 pub fn reset_pos() -> String {
-    return format!("G92.1\n")
+    "G92.1\n".to_string()
 }
 
-
 /// Returns a M104 command to set target hotend temp as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::set_hotend_temp;
-/// 
+///
 /// let gcode = set_hotend_temp(210, None);
 /// assert_eq!("M104 S210\n", gcode);
 /// ```
-/// 
+///
 /// To specify an extruder other than default (last active):
 /// ```
 /// extern crate gen_gcode;
@@ -611,26 +630,25 @@ pub fn reset_pos() -> String {
 /// assert_eq!("M104 S210 T2\n", gcode);
 /// ```
 pub fn set_hotend_temp(temp: u16, hotend: Option<u8>) -> String {
-    let t_str: String;
-    if let Some(maybe_hotend) = hotend {
-        t_str = format!(" T{}", maybe_hotend);
-    } else {
-        t_str = format!("");
-    }
-    return format!("M104 S{s}{t}\n", s=temp, t=t_str)
+    let t_str = match hotend {
+        Some(hotend) => format!(" T{}", hotend), 
+        None => String::new()
+    };
+
+    format!("M104 S{s}{t}\n", s = temp, t = t_str)
 }
 
 /// Returns a M109 command to set target hotend temp to wait to reach as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::wait_hotend_temp;
-/// 
+///
 /// let gcode = wait_hotend_temp(210, None);
 /// assert_eq!("M109 S210\n", gcode);
 /// ```
-/// 
+///
 /// To specify an extruder other than default (last active):
 /// ```
 /// extern crate gen_gcode;
@@ -640,43 +658,41 @@ pub fn set_hotend_temp(temp: u16, hotend: Option<u8>) -> String {
 /// assert_eq!("M109 S210 T2\n", gcode);
 /// ```
 pub fn wait_hotend_temp(temp: u16, hotend: Option<u8>) -> String {
-    let t_str: String;
-    if let Some(maybe_hotend) = hotend {
-        t_str = format!(" T{}", maybe_hotend);
-    } else {
-        t_str = format!("");
-    }
-    return format!("M109 S{s}{t}\n", s=temp, t=t_str)
+    let t_str = match hotend {
+        Some(hotend) => format!(" T{}", hotend),
+        None => String::new(),
+    };
+
+    format!("M109 S{s}{t}\n", s = temp, t = t_str)
 }
 
 /// Returns a M106 command to set the fan speed, with optional fan index, as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::set_fan_speed;
-/// 
+///
 /// //set default fan to half speed
 /// let gcode = set_fan_speed(128, None);
 /// assert_eq!("M106 S128\n", gcode);
 /// ```
-/// 
+///
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::set_fan_speed;
-/// 
+///
 /// //set alternate fan to full speed
 /// let gcode = set_fan_speed(u8::MAX, Some(1));
 /// assert_eq!("M106 S255 P1\n", gcode);
 /// ```
 pub fn set_fan_speed(speed: u8, fan: Option<u8>) -> String {
-    let p_str: String;
-    if let Some(maybe_fan) = fan {
-        p_str = format!(" P{}", maybe_fan);
-    } else {
-        p_str = format!("");
-    }
-    return format!("M106 S{s}{p}\n", s=speed, p=p_str)
+    let p_str = match fan {
+        Some(maybe_fan) => format!(" P{}", maybe_fan),
+        None => String::new(),
+    };
+
+    format!("M106 S{s}{p}\n", s = speed, p = p_str)
 }
 
 /// Returns a M107 command to disable the fan, with optional fan index, as a String
@@ -698,108 +714,106 @@ pub fn set_fan_speed(speed: u8, fan: Option<u8>) -> String {
 /// assert_eq!("M107 P3\n", gcode);
 /// ```
 pub fn fan_off(fan: Option<u8>) -> String {
-    let p_str: String;
-    if let Some(maybe_fan) = fan {
-        p_str = format!(" P{}", maybe_fan);
-    } else {
-        p_str = format!("");
-    }
-    return format!("M107{p}\n", p=p_str)
+    let p_str = match fan {
+        Some(maybe_fan) => format!(" P{}", maybe_fan),
+        None => String::new(),
+    };
+
+    format!("M107{p}\n", p = p_str)
 }
 
 /// Returns a M140 command to set bed hotend temp as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::set_bed_temp;
-/// 
+///
 /// let gcode = set_bed_temp(210);
 /// assert_eq!("M140 S210\n", gcode);
 /// ```
 pub fn set_bed_temp(temp: u8) -> String {
-    return format!("M140 S{}\n", temp)
+    format!("M140 S{}\n", temp)
 }
 
 /// Returns a M190 command to set target bed temp to wait to reach as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::wait_bed_temp;
-/// 
+///
 /// let gcode = wait_bed_temp(210);
 /// assert_eq!("M190 S210\n", gcode);
 /// ```
 pub fn wait_bed_temp(temp: u8) -> String {
-    return format!("M190 S{}\n", temp)
+    format!("M190 S{}\n", temp)
 }
 
 /// Returns a M141 command to set target chamber temp as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::set_chamber_temp;
-/// 
+///
 /// let gcode = set_chamber_temp(50);
 /// assert_eq!("M141 S50\n", gcode);
 /// ```
 pub fn set_chamber_temp(temp: u8) -> String {
-    return format!("M141 S{}\n", temp)
+    format!("M141 S{}\n", temp)
 }
 
-
 /// Returns a M191 command to set target chamber temp to wait to reach as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::wait_chamber_temp;
-/// 
+///
 /// let gcode = wait_chamber_temp(50);
 /// assert_eq!("M191 S50\n", gcode);
 /// ```
 pub fn wait_chamber_temp(temp: u8) -> String {
-    return format!("M191 S{}\n", temp)
+    format!("M191 S{}\n", temp)
 }
 
 /// Returns a G28 command to trigger autohome procedure, using default parameters set in machine firmware, as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::auto_home;
-/// 
+///
 /// let gcode = auto_home();
 /// assert_eq!("G28\n", gcode);
 /// ```
 pub fn auto_home() -> String {
-    return format!("G28\n")
+    "G28\n".to_string()
 }
 
 /// Returns a M82 command to set the extruder axis to absolute mode, independant of other axes, as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::absolute_extrution;
-/// 
+///
 /// let gcode = absolute_extrution();
 /// assert_eq!("M82\n", gcode);
 pub fn absolute_extrution() -> String {
-    return format!("M82\n")
+    "M82\n".to_string()
 }
 
 /// Returns a M83 command to set the extruder axis to relative mode, independant of other axes, as a String
-/// 
+///
 /// # Examples
 /// ```
 /// extern crate gen_gcode;
 /// use gen_gcode::relative_extrution;
-/// 
+///
 /// let gcode = relative_extrution();
 /// assert_eq!("M83\n", gcode);
 pub fn relative_extrution() -> String {
-    return format!("M83\n")
+    "M83\n".to_string()
 }


### PR DESCRIPTION
Mostly code changes suggested by clippy:
- use `switch` instead of `if Some(...) {} else {}`
- use `"...".to_string()` instead of `return format!(...)`

And also includes deleting spaces from empty lines.